### PR TITLE
Delete 'bottle :unneeded', trim whitespace.

### DIFF
--- a/Formula/astro.rb
+++ b/Formula/astro.rb
@@ -6,8 +6,7 @@ class Astro < Formula
   desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.26.0"
-  bottle :unneeded
-   
+
   on_macos do
     if Hardware::CPU.intel?
       url "https://github.com/astronomer/astro-cli/releases/download/v0.26.0/astro_0.26.0_darwin_amd64.tar.gz"

--- a/Formula/astro@0.13.1.rb
+++ b/Formula/astro@0.13.1.rb
@@ -3,7 +3,6 @@ class AstroAT0131 < Formula
   desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.13.1"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/astronomer/astro-cli/releases/download/v0.13.1/astro_0.13.1_darwin_amd64.tar.gz"
@@ -14,7 +13,7 @@ class AstroAT0131 < Formula
       sha256 "fb8d5b66922b459b6a936ef718d44cb16db046a73e3aaa97ccda9ab48d1c43e2"
     end
   end
-  
+
   def install
     bin.install "astro"
   end

--- a/Formula/astro@0.15.0.rb
+++ b/Formula/astro@0.15.0.rb
@@ -3,7 +3,6 @@ class AstroAT0150 < Formula
   desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.15.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/astronomer/astro-cli/releases/download/v0.15.0/astro_0.15.0_darwin_amd64.tar.gz"
@@ -14,7 +13,7 @@ class AstroAT0150 < Formula
       sha256 "664fc5d7844a00ff1da17f1ff13889c0138a3b4ae4f66007cc5ddb54f14deeac"
     end
   end
-  
+
   def install
     bin.install "astro"
   end

--- a/Formula/astro@0.16.0.rb
+++ b/Formula/astro@0.16.0.rb
@@ -3,7 +3,6 @@ class AstroAT0160 < Formula
   desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.16.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/astronomer/astro-cli/releases/download/v0.16.0/astro_0.16.0_darwin_amd64.tar.gz"

--- a/Formula/astro@0.16.1.rb
+++ b/Formula/astro@0.16.1.rb
@@ -3,7 +3,6 @@ class AstroAT0161 < Formula
   desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.16.1"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/astronomer/astro-cli/releases/download/v0.16.1/astro_0.16.1_darwin_amd64.tar.gz"
@@ -14,7 +13,7 @@ class AstroAT0161 < Formula
       sha256 "4ed9688fb016644147fbbd166998cb16511a2cf064f8a0cd43916d4de8e48c6b"
     end
   end
-  
+
   def install
     bin.install "astro"
   end

--- a/Formula/astro@0.16.2.rb
+++ b/Formula/astro@0.16.2.rb
@@ -3,7 +3,6 @@ class AstroAT0162 < Formula
   desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.16.2"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/astronomer/astro-cli/releases/download/v0.16.2/astro_0.16.2_darwin_amd64.tar.gz"
@@ -14,7 +13,7 @@ class AstroAT0162 < Formula
       sha256 "659928709bfe32a86c7368a151053f61eca9c74c3ab5bdcbfa29966a939205a1"
     end
   end
-  
+
   def install
     bin.install "astro"
   end

--- a/Formula/astro@0.16.3.rb
+++ b/Formula/astro@0.16.3.rb
@@ -3,7 +3,6 @@ class AstroAT0163 < Formula
   desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.16.3"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/astronomer/astro-cli/releases/download/v0.16.3/astro_0.16.3_darwin_amd64.tar.gz"
@@ -14,7 +13,7 @@ class AstroAT0163 < Formula
       sha256 "b2788d92766b9fe48fc3ef7834edade08e58a36f4afde6e3cfd3efa9f6730886"
     end
   end
-  
+
   def install
     bin.install "astro"
   end

--- a/Formula/astro@0.16.4.rb
+++ b/Formula/astro@0.16.4.rb
@@ -3,7 +3,6 @@ class AstroAT0164 < Formula
   desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.16.4"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/astronomer/astro-cli/releases/download/v0.16.4/astro_0.16.4_darwin_amd64.tar.gz"

--- a/Formula/astro@0.16.5.rb
+++ b/Formula/astro@0.16.5.rb
@@ -3,7 +3,6 @@ class AstroAT0165 < Formula
   desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.16.5"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/astronomer/astro-cli/releases/download/v0.16.5/astro_0.16.5_darwin_amd64.tar.gz"

--- a/Formula/astro@0.17.0.rb
+++ b/Formula/astro@0.17.0.rb
@@ -3,7 +3,6 @@ class AstroAT0170 < Formula
   desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.17.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/astronomer/astro-cli/releases/download/v0.17.0/astro_0.17.0_darwin_amd64.tar.gz"
@@ -14,7 +13,7 @@ class AstroAT0170 < Formula
       sha256 "4bc0e7fe0c9c90e43a2a9471b1352829196d79924d83b0407d59d478bde6b96a"
     end
   end
-  
+
   def install
     bin.install "astro"
   end

--- a/Formula/astro@0.18.0.rb
+++ b/Formula/astro@0.18.0.rb
@@ -3,21 +3,20 @@ class AstroAT0180 < Formula
   desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.18.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/astronomer/astro-cli/releases/download/v0.18.0/astro_0.18.0_darwin_amd64.tar.gz"
     sha256 "bdc0dc39e41202f5d2fbec0363acb72ee8e7d3dc45fda365e6ba6d5b9eccfb40"
   elsif OS.linux?
     if Hardware::CPU.is_64_bit?
-      url "https://github.com/astronomer/astro-cli/releases/download/v0.18.0/astro_0.18.0_linux_amd64.tar.gz"  
+      url "https://github.com/astronomer/astro-cli/releases/download/v0.18.0/astro_0.18.0_linux_amd64.tar.gz"
       sha256 "b0e9e1a26e9bfce36ecc0170b126316d67f9ac4a20a85c8fadb69dc72550805d"
     else
       url "https://github.com/astronomer/astro-cli/releases/download/v0.18.0/astro_0.18.0_linux_386.tar.gz"
       sha256 "bb04f6027da2414fdd4e29e9f25fde8e47721fb30add14ba42c4f6990312756d"
     end
   end
-  
+
   def install
     bin.install "astro"
   end

--- a/Formula/astro@0.19.0.rb
+++ b/Formula/astro@0.19.0.rb
@@ -3,7 +3,6 @@ class AstroAT0190 < Formula
   desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.19.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/astronomer/astro-cli/releases/download/v0.19.0/astro_0.19.0_darwin_amd64.tar.gz"

--- a/Formula/astro@0.20.0.rb
+++ b/Formula/astro@0.20.0.rb
@@ -3,7 +3,6 @@ class AstroAT0200 < Formula
   desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.20.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/astronomer/astro-cli/releases/download/v0.20.0/astro_0.20.0_darwin_amd64.tar.gz"

--- a/Formula/astro@0.21.0.rb
+++ b/Formula/astro@0.21.0.rb
@@ -3,7 +3,6 @@ class AstroAT0210 < Formula
   desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.21.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/astronomer/astro-cli/releases/download/v0.21.0/astro_0.21.0_darwin_amd64.tar.gz"

--- a/Formula/astro@0.22.0.rb
+++ b/Formula/astro@0.22.0.rb
@@ -3,7 +3,6 @@ class AstroAT0220 < Formula
   desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.22.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/astronomer/astro-cli/releases/download/v0.22.0/astro_0.22.0_darwin_amd64.tar.gz"

--- a/Formula/astro@0.22.1.rb
+++ b/Formula/astro@0.22.1.rb
@@ -3,7 +3,6 @@ class AstroAT0221 < Formula
   desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.22.1"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/astronomer/astro-cli/releases/download/v0.22.1/astro_0.22.1_darwin_amd64.tar.gz"

--- a/Formula/astro@0.22.2.rb
+++ b/Formula/astro@0.22.2.rb
@@ -3,7 +3,6 @@ class AstroAT0222 < Formula
   desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.22.2"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/astronomer/astro-cli/releases/download/v0.22.2/astro_0.22.2_darwin_amd64.tar.gz"

--- a/Formula/astro@0.23.0.rb
+++ b/Formula/astro@0.23.0.rb
@@ -3,7 +3,6 @@ class AstroAT0230 < Formula
   desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.23.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/astronomer/astro-cli/releases/download/v0.23.0/astro_0.23.0_darwin_amd64.tar.gz"

--- a/Formula/astro@0.23.1.rb
+++ b/Formula/astro@0.23.1.rb
@@ -3,7 +3,6 @@ class AstroAT0231 < Formula
   desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.23.1"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/astronomer/astro-cli/releases/download/v0.23.1/astro_0.23.1_darwin_amd64.tar.gz"

--- a/Formula/astro@0.23.2.rb
+++ b/Formula/astro@0.23.2.rb
@@ -3,7 +3,6 @@ class AstroAT0232 < Formula
   desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.23.2"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/astronomer/astro-cli/releases/download/v0.23.2/astro_0.23.2_darwin_amd64.tar.gz"

--- a/Formula/astro@0.23.3.rb
+++ b/Formula/astro@0.23.3.rb
@@ -3,7 +3,6 @@ class AstroAT0233 < Formula
   desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.23.3"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/astronomer/astro-cli/releases/download/v0.23.3/astro_0.23.3_darwin_amd64.tar.gz"

--- a/Formula/astro@0.23.4.rb
+++ b/Formula/astro@0.23.4.rb
@@ -3,7 +3,6 @@ class AstroAT0234 < Formula
   desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.23.4"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/astronomer/astro-cli/releases/download/v0.23.4/astro_0.23.4_darwin_amd64.tar.gz"

--- a/Formula/astro@0.25.0.rb
+++ b/Formula/astro@0.25.0.rb
@@ -3,7 +3,6 @@ class AstroAT0250 < Formula
  desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.25.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/astronomer/astro-cli/releases/download/v0.25.0/astro_0.25.0_darwin_amd64.tar.gz"

--- a/Formula/astro@0.25.1.rb
+++ b/Formula/astro@0.25.1.rb
@@ -6,7 +6,6 @@ class AstroAT0251 < Formula
   desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.25.1"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?

--- a/Formula/astro@0.25.4.rb
+++ b/Formula/astro@0.25.4.rb
@@ -6,8 +6,7 @@ class AstroAT0254 < Formula
   desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.25.4"
-  bottle :unneeded
-  
+
   on_macos do
     if Hardware::CPU.intel?
       url "https://github.com/astronomer/astro-cli/releases/download/v0.25.4/astro_0.25.4_darwin_amd64.tar.gz"

--- a/Formula/astro@0.25.5.rb
+++ b/Formula/astro@0.25.5.rb
@@ -6,8 +6,7 @@ class AstroAT0255 < Formula
   desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.25.5"
-  bottle :unneeded
-   
+
   on_macos do
     if Hardware::CPU.intel?
       url "https://github.com/astronomer/astro-cli/releases/download/v0.25.5/astro_0.25.5_darwin_amd64.tar.gz"

--- a/Formula/astro@0.26.0.rb
+++ b/Formula/astro@0.26.0.rb
@@ -6,8 +6,7 @@ class AstroAT0260 < Formula
   desc "To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API."
   homepage "https://astronomer.io"
   version "0.26.0"
-  bottle :unneeded
-   
+
   on_macos do
     if Hardware::CPU.intel?
       url "https://github.com/astronomer/astro-cli/releases/download/v0.26.0/astro_0.26.0_darwin_amd64.tar.gz"


### PR DESCRIPTION
Fixes error:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the astronomer/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/astronomer/homebrew-tap/Formula/astro.rb:9
```