### PR TITLE
patching existing formulas for m1 mac release

### DIFF
--- a/Formula/astro@0.25.1.rb
+++ b/Formula/astro@0.25.1.rb
@@ -8,10 +8,8 @@ class AstroAT0251 < Formula
   version "0.25.1"
 
   on_macos do
-    if Hardware::CPU.intel?
-      url "https://github.com/astronomer/astro-cli/releases/download/v0.25.1/astro_0.25.1_darwin_amd64.tar.gz"
-      sha256 "17c5c1d468076b87b0b986afb88145c158f20fa3606714d87378c7e3ccbd2338"
-    end
+    url "https://github.com/astronomer/astro-cli/releases/download/v0.25.1/astro_0.25.1_darwin_amd64.tar.gz"
+    sha256 "17c5c1d468076b87b0b986afb88145c158f20fa3606714d87378c7e3ccbd2338"
   end
 
   on_linux do

--- a/Formula/astro@0.25.4.rb
+++ b/Formula/astro@0.25.4.rb
@@ -8,10 +8,8 @@ class AstroAT0254 < Formula
   version "0.25.4"
 
   on_macos do
-    if Hardware::CPU.intel?
-      url "https://github.com/astronomer/astro-cli/releases/download/v0.25.4/astro_0.25.4_darwin_amd64.tar.gz"
-      sha256 "5efa79b11f24b7df9f270babaaa5e05d06c98d12851c7341ec37d4ac7cf6ba1f"
-    end
+    url "https://github.com/astronomer/astro-cli/releases/download/v0.25.4/astro_0.25.4_darwin_amd64.tar.gz"
+    sha256 "5efa79b11f24b7df9f270babaaa5e05d06c98d12851c7341ec37d4ac7cf6ba1f"
   end
 
   on_linux do

--- a/Formula/astro@0.25.5.rb
+++ b/Formula/astro@0.25.5.rb
@@ -8,10 +8,8 @@ class AstroAT0255 < Formula
   version "0.25.5"
 
   on_macos do
-    if Hardware::CPU.intel?
-      url "https://github.com/astronomer/astro-cli/releases/download/v0.25.5/astro_0.25.5_darwin_amd64.tar.gz"
-      sha256 "6faa1024d053e6291ef23302380c4b703ca5b8dfd6d518445e5ecf2c99c978c9"
-    end
+    url "https://github.com/astronomer/astro-cli/releases/download/v0.25.5/astro_0.25.5_darwin_amd64.tar.gz"
+    sha256 "6faa1024d053e6291ef23302380c4b703ca5b8dfd6d518445e5ecf2c99c978c9"
   end
 
   on_linux do

--- a/Formula/astro@0.26.0.rb
+++ b/Formula/astro@0.26.0.rb
@@ -8,10 +8,8 @@ class AstroAT0260 < Formula
   version "0.26.0"
 
   on_macos do
-    if Hardware::CPU.intel?
-      url "https://github.com/astronomer/astro-cli/releases/download/v0.26.0/astro_0.26.0_darwin_amd64.tar.gz"
-      sha256 "e978c6deb2d02d32aeff97571041ea1ca9c5b1cd547c052d27c5698195fe7f6d"
-    end
+    url "https://github.com/astronomer/astro-cli/releases/download/v0.26.0/astro_0.26.0_darwin_amd64.tar.gz"
+    sha256 "e978c6deb2d02d32aeff97571041ea1ca9c5b1cd547c052d27c5698195fe7f6d"
   end
 
   on_linux do

--- a/Formula/astro@0.26.1.rb
+++ b/Formula/astro@0.26.1.rb
@@ -8,10 +8,8 @@ class AstroAT0261 < Formula
   version "0.26.1"
 
   on_macos do
-    if Hardware::CPU.intel?
-      url "https://github.com/astronomer/astro-cli/releases/download/v0.26.1/astro_0.26.1_darwin_amd64.tar.gz"
-      sha256 "7bf7d9d911bcf9ed462775748f0de4fee0904c8ab66d42591081b06d0e30401c"
-    end
+    url "https://github.com/astronomer/astro-cli/releases/download/v0.26.1/astro_0.26.1_darwin_amd64.tar.gz"
+    sha256 "7bf7d9d911bcf9ed462775748f0de4fee0904c8ab66d42591081b06d0e30401c"
   end
 
   on_linux do

--- a/Formula/astro@0.26.2.rb
+++ b/Formula/astro@0.26.2.rb
@@ -8,10 +8,8 @@ class AstroAT0262 < Formula
   version "0.26.2"
 
   on_macos do
-    if Hardware::CPU.intel?
-      url "https://github.com/astronomer/astro-cli/releases/download/v0.26.2/astro_0.26.2_darwin_amd64.tar.gz"
-      sha256 "b69566d143f6fb6cd651e7d0ebba1882113cccd4918ae2dc4552b1c49cb2ca00"
-    end
+    url "https://github.com/astronomer/astro-cli/releases/download/v0.26.2/astro_0.26.2_darwin_amd64.tar.gz"
+    sha256 "b69566d143f6fb6cd651e7d0ebba1882113cccd4918ae2dc4552b1c49cb2ca00"
   end
 
   on_linux do

--- a/Formula/astro@0.27.0.rb
+++ b/Formula/astro@0.27.0.rb
@@ -8,10 +8,8 @@ class AstroAT0270 < Formula
     version "0.27.0"
   
     on_macos do
-      if Hardware::CPU.intel?
-        url "https://github.com/astronomer/astro-cli/releases/download/v0.27.0/astro_0.27.0_darwin_amd64.tar.gz"
-        sha256 "b6aed7745808c8fcea24e2f2a90e9b5a0164621619c8ba68d833242f8c3e09da"
-      end
+      url "https://github.com/astronomer/astro-cli/releases/download/v0.27.0/astro_0.27.0_darwin_amd64.tar.gz"
+      sha256 "b6aed7745808c8fcea24e2f2a90e9b5a0164621619c8ba68d833242f8c3e09da"
     end
   
     on_linux do

--- a/Formula/astro@0.27.1.rb
+++ b/Formula/astro@0.27.1.rb
@@ -8,10 +8,8 @@ class AstroAT0271 < Formula
     version "0.27.1"
   
     on_macos do
-      if Hardware::CPU.intel?
-        url "https://github.com/astronomer/astro-cli/releases/download/v0.27.1/astro_0.27.1_darwin_amd64.tar.gz"
-        sha256 "e63f8a235943c5c12a1a08038f1575f55cc2484e89352bc526b0d98933beae97"
-      end
+      url "https://github.com/astronomer/astro-cli/releases/download/v0.27.1/astro_0.27.1_darwin_amd64.tar.gz"
+      sha256 "e63f8a235943c5c12a1a08038f1575f55cc2484e89352bc526b0d98933beae97"
     end
   
     on_linux do


### PR DESCRIPTION
Changes:
Removed check on hardware for macOS, so that 0.27.2 onwards releases can pass through, as of now when trying to install 0.27.2 on M1 mac will give following error:
```
Error: Invalid formula: /opt/homebrew/Library/Taps/astronomer/homebrew-tap/Formula/astro@0.26.0.rb
formulae require at least a URL
Error: Invalid formula: /opt/homebrew/Library/Taps/astronomer/homebrew-tap/Formula/astro@0.27.1.rb
formulae require at least a URL
Error: Invalid formula: /opt/homebrew/Library/Taps/astronomer/homebrew-tap/Formula/astro@0.26.1.rb
formulae require at least a URL
Error: Invalid formula: /opt/homebrew/Library/Taps/astronomer/homebrew-tap/Formula/astro@0.27.0.rb
formulae require at least a URL
Error: Invalid formula: /opt/homebrew/Library/Taps/astronomer/homebrew-tap/Formula/astro@0.26.2.rb
formulae require at least a URL
Error: Invalid formula: /opt/homebrew/Library/Taps/astronomer/homebrew-tap/Formula/astro@0.25.5.rb
formulae require at least a URL
Error: Invalid formula: /opt/homebrew/Library/Taps/astronomer/homebrew-tap/Formula/astro@0.25.1.rb
formulae require at least a URL
Error: Invalid formula: /opt/homebrew/Library/Taps/astronomer/homebrew-tap/Formula/astro@0.25.4.rb
formulae require at least a URL
Error: Cannot tap astronomer/tap: invalid syntax in tap!
```
As all these releases don't have a valid entry for M1 mac, and the only way we use to install astro-cli on M1 till now was by using Rosetta2 to emulate as intel mac (using `arch -x86_64` in prefix), which should still work for existing releases after this change.